### PR TITLE
makefile: fix compile error for GCC 4.6 or above

### DIFF
--- a/app/shell/Makefile
+++ b/app/shell/Makefile
@@ -12,7 +12,7 @@ MACH_CFLAGS = -march=armv5te -mtune=xscale -Wa,-mcpu=xscale \
 CFLAGS = \
 	-I../../includes/arch/arm/mach-pxa \
 	-I../../includes \
-	-Wall -Werror \
+	-Wall -Werror -Wno-error=unused-but-set-variable \
 	-fno-builtin \
 	-O0 -g $(MACH_CFLAGS)
 


### PR DESCRIPTION
GCC 4.6 chage the behavior of -Wall, which now include
-Wunused-but-set-variable warning flag and will cause following compile
error for GCC 4.6 or above.

Compile error as following:

 ../../lib/stdio.c: In function '_PrintHex':
 ../../lib/stdio.c:174:6: error: variable 'cnt' set but not used [-Werror=unused-but-set-variable]
 ../../lib/stdio.c:170:22: error: variable 'flagl' set but not used [-Werror=unused-but-set-variable]
 ../../lib/stdio.c: In function 'strtoul':
 ../../lib/stdio.c:414:16: error: variable 'strtoul_err' set but not used [-Werror=unused-but-set-variable]
 cc1: all warnings being treated as errors
 make[1]: **\* [../../lib/stdio.o] Error 1

To prevent compile error, add -Wno-error=unused-but-set-variable seems
the best solution in our case, for more info please see following link

  http://gcc.gnu.org/gcc-4.6/porting_to.html

Signed-off-by: coldnew coldnew.tw@gmail.com
